### PR TITLE
feat(internal-gateway): bump proxy buffer limits

### DIFF
--- a/charts/internal-gateway/Chart.yaml
+++ b/charts/internal-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.0.0
 description: A Helm chart for Codefresh Internal Gateway
 name: internal-gateway
-version: 0.5.0
+version: 0.6.0
 home: https://github.com/codefresh-io/helm-charts
 keywords:
   - codefresh

--- a/charts/internal-gateway/README.md
+++ b/charts/internal-gateway/README.md
@@ -1,6 +1,6 @@
 # internal-gateway
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
 
 A Helm chart for Codefresh Internal Gateway
 

--- a/charts/internal-gateway/templates/_location_map.tpl
+++ b/charts/internal-gateway/templates/_location_map.tpl
@@ -15,10 +15,10 @@ locationSnippet: |
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_redirect off;
 locationDirectives:
-  proxy_buffer_size: "64k"
-  proxy_buffers: "4 64k"
-  client_max_body_size: "5M"
-  client_body_buffer_size: "16k"
+  proxy_buffer_size: "128k"
+  proxy_buffers: "4 128k"
+  client_max_body_size: "10M"
+  client_body_buffer_size: "32k"
   proxy_connect_timeout: "5s"
   proxy_send_timeout: "60s"
   proxy_read_timeout: "60s"


### PR DESCRIPTION
## What

Bump default proxy buffer limits in internal-gateway

## Why

Required for `X-CF-Auth-Entity` header when user is invited into more than 100 accounts

## Notes