### PR TITLE
fix(internal-gateway): default values

### DIFF
--- a/charts/internal-gateway/Chart.yaml
+++ b/charts/internal-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.0.0
 description: A Helm chart for Codefresh Internal Gateway
 name: internal-gateway
-version: 0.8.0
+version: 0.8.1
 home: https://github.com/codefresh-io/helm-charts
 keywords:
   - codefresh

--- a/charts/internal-gateway/README.md
+++ b/charts/internal-gateway/README.md
@@ -1,6 +1,6 @@
 # internal-gateway
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
 
 A Helm chart for Codefresh Internal Gateway
 
@@ -46,7 +46,6 @@ A Helm chart for Codefresh Internal Gateway
 | nginx.config.resolver | string | `nil` | Allows to set a custom resolver |
 | nginx.config.serverDirectives | object | `{}` | Allows appending custom directives to the server block (map) |
 | nginx.config.serverSnippet | string | `""` | Allows appending custom configuration to the server block (string) |
-| nginx.config.signadot | bool | `false` | Misc signadot configuration |
 | nginx.config.verboseLogging | bool | `false` | Enable logging of 2xx and 3xx HTTP requests |
 | nginx.config.workerConnections | string | `"16384"` | Sets the maximum number of simultaneous connections that can be opened by a worker process. |
 | nginx.config.workerProcesses | string | `"8"` | Defines the number of worker processes. |
@@ -57,6 +56,7 @@ A Helm chart for Codefresh Internal Gateway
 | rbac | object | See below | RBAC parameters |
 | service | object | See below | Service parameters |
 | serviceAccount | object | See below | Service Account parameters |
+| signadot | bool | `false` | Misc signadot configuration |
 | topologySpreadConstraints | string | See below | Topologe Spread Constraints parameters |
 | volumes | object | See below | Volumes parameters |
 

--- a/charts/internal-gateway/values.yaml
+++ b/charts/internal-gateway/values.yaml
@@ -148,8 +148,9 @@ nginx:
     # !! Moved into separate template at `templates/nginx/configmap.yaml`
     # @default -- See below
     file: ""
-    # -- Misc signadot configuration
-    signadot: false
+
+# -- Misc signadot configuration
+signadot: false
 
 # -- Controller parameters
 # @default -- See below


### PR DESCRIPTION
## What

Put default `signadot` value in the correct context

## Why

## Notes