### PR TITLE
feat(cf-common): global imagePullSecrets with name

### DIFF
--- a/charts/cf-common-test/tests/deployment/container_test.yaml
+++ b/charts/cf-common-test/tests/deployment/container_test.yaml
@@ -432,7 +432,7 @@ tests:
                 name: some-secret-one
                 key: some-key-one
 
-  - it: Test main container with image digest 
+  - it: Test main container with image digest
     values:
       - values.yaml
     set:

--- a/charts/cf-common-test/tests/deployment/spec_test.yaml
+++ b/charts/cf-common-test/tests/deployment/spec_test.yaml
@@ -64,6 +64,21 @@ tests:
           content:
             name: cf-ecr-codefresh-registry
 
+  - it: Test deploymeny with global imagePullSecrets
+    release:
+      name: cf
+    values:
+      - values.yaml
+    set:
+      global:
+        imagePullSecrets:
+          - name: test-global-pull-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: test-global-pull-secret
+
   - it: Test deployment's initContainer is present and valid
     values:
       - values.yaml

--- a/charts/cf-common/Chart.yaml
+++ b/charts/cf-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.0.0
 description: Codefresh library chart
 name: cf-common
-version: 0.25.0
+version: 0.26.0
 type: library
 keywords:
   - codefresh

--- a/charts/cf-common/README.md
+++ b/charts/cf-common/README.md
@@ -2,7 +2,7 @@
 
 Codefresh library chart
 
-![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
+![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
 
 ## Installing the Chart
 
@@ -18,7 +18,7 @@ Include this chart as a dependency in your `Chart.yaml` e.g.
 # Chart.yaml
 dependencies:
 - name: cf-common
-  version: 0.25.0
+  version: 0.26.0
   repository: https://chartmuseum.codefresh.io/cf-common
 ```
 

--- a/charts/cf-common/templates/classic/_env_var_secret_ref.tpl
+++ b/charts/cf-common/templates/classic/_env_var_secret_ref.tpl
@@ -1,18 +1,18 @@
 {{- /*
 MONGODB_HOST env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.mongodb-host-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.mongodb-host-env-var-secret-name" }}
   {{- if or .Values.mongodbHostSecretKeyRef .Values.global.mongodbHostSecretKeyRef }}
 {{- printf (coalesce .Values.mongodbHostSecretKeyRef.name .Values.global.mongodbHostSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 MONGODB_HOST env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.mongodb-host-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.mongodb-host-env-var-secret-key" }}
   {{- if or .Values.mongodbHostSecretKeyRef .Values.global.mongodbHostSecretKeyRef }}
 {{- printf (coalesce .Values.mongodbHostSecretKeyRef.key .Values.global.mongodbHostSecretKeyRef.key) }}
   {{- else }}
@@ -23,18 +23,18 @@ MONGODB_HOST env var secret key
 {{- /*
 MONGODB_USER env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.mongodb-user-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.mongodb-user-env-var-secret-name" }}
   {{- if or .Values.mongodbUserSecretKeyRef .Values.global.mongodbUserSecretKeyRef }}
 {{- printf (coalesce .Values.mongodbUserSecretKeyRef.name .Values.global.mongodbUserSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 MONGODB_USER env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.mongodb-user-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.mongodb-user-env-var-secret-key" }}
   {{- if or .Values.mongodbUserSecretKeyRef .Values.global.mongodbUserSecretKeyRef }}
 {{- printf (coalesce .Values.mongodbUserSecretKeyRef.key .Values.global.mongodbUserSecretKeyRef.key) }}
   {{- else }}
@@ -45,18 +45,18 @@ MONGODB_USER env var secret key
 {{- /*
 MONGODB_PASSWORD env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.mongodb-password-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.mongodb-password-env-var-secret-name" }}
   {{- if or .Values.mongodbPasswordSecretKeyRef .Values.global.mongodbPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.mongodbPasswordSecretKeyRef.name .Values.global.mongodbPasswordSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 MONGODB_PASSWORD env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.mongodb-password-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.mongodb-password-env-var-secret-key" }}
   {{- if or .Values.mongodbPasswordSecretKeyRef .Values.global.mongodbPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.mongodbPasswordSecretKeyRef.key .Values.global.mongodbPasswordSecretKeyRef.key) }}
   {{- else }}
@@ -67,7 +67,7 @@ MONGODB_PASSWORD env var secret key
 {{- /*
 MONGO_URI env var value
 */}}
-{{- define "cf-common-0.25.0.classic.mongo-uri-env-var-value" }}
+{{- define "cf-common-0.26.0.classic.mongo-uri-env-var-value" }}
 {{- /*
 Check for legacy global.mongoURI
 */}}
@@ -84,7 +84,7 @@ New secret implementation
 {{- /*
 MONGO_URI_ARCHIVE env var value
 */}}
-{{- define "cf-common-0.25.0.classic.mongo-uri-archive-env-var-value" }}
+{{- define "cf-common-0.26.0.classic.mongo-uri-archive-env-var-value" }}
 {{- /*
 Check for legacy global.mongoURIArchive or global.mongoURI
 */}}
@@ -102,18 +102,18 @@ New secret implementation
 {{- /*
 REDIS_URL env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.redis-url-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.redis-url-env-var-secret-name" }}
   {{- if or .Values.redisUrlSecretKeyRef .Values.global.redisUrlSecretKeyRef }}
 {{- printf (coalesce .Values.redisUrlSecretKeyRef.name .Values.global.redisUrlSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 REDIS_URL env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.redis-url-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.redis-url-env-var-secret-key" }}
   {{- if or .Values.redisUrlSecretKeyRef .Values.global.redisUrlSecretKeyRef }}
 {{- printf (coalesce .Values.redisUrlSecretKeyRef.key .Values.global.redisUrlSecretKeyRef.key) }}
   {{- else }}
@@ -124,18 +124,18 @@ REDIS_URL env var secret key
 {{- /*
 REDIS_PASSWORD env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.redis-password-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.redis-password-env-var-secret-name" }}
   {{- if or .Values.redisPasswordSecretKeyRef .Values.global.redisPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.redisPasswordSecretKeyRef.name .Values.global.redisPasswordSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 REDIS_PASSWORD env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.redis-password-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.redis-password-env-var-secret-key" }}
   {{- if or .Values.redisPasswordSecretKeyRef .Values.global.redisPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.redisPasswordSecretKeyRef.key .Values.global.redisPasswordSecretKeyRef.key) }}
   {{- else }}
@@ -146,18 +146,18 @@ REDIS_PASSWORD env var secret key
 {{- /*
 POSTGRES_HOSTNAME env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.postgres-hostname-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.postgres-hostname-env-var-secret-name" }}
   {{- if or .Values.postgresHostnameSecretKeyRef .Values.global.postgresHostnameSecretKeyRef }}
 {{- printf (coalesce .Values.postgresHostnameSecretKeyRef.name .Values.global.postgresHostnameSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 POSTGRES_HOSTNAME env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.postgres-hostname-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.postgres-hostname-env-var-secret-key" }}
   {{- if or .Values.postgresHostnameSecretKeyRef .Values.global.postgresHostnameSecretKeyRef }}
 {{- printf (coalesce .Values.postgresHostnameSecretKeyRef.key .Values.global.postgresHostnameSecretKeyRef.key) }}
   {{- else }}
@@ -168,18 +168,18 @@ POSTGRES_HOSTNAME env var secret key
 {{- /*
 POSTGRES_PASSWORD env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.postgres-password-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.postgres-password-env-var-secret-name" }}
   {{- if or .Values.postgresPasswordSecretKeyRef .Values.global.postgresPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.postgresPasswordSecretKeyRef.name .Values.global.postgresPasswordSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 POSTGRES_PASSWORD env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.postgres-password-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.postgres-password-env-var-secret-key" }}
   {{- if or .Values.postgresPasswordSecretKeyRef .Values.global.postgresPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.postgresPasswordSecretKeyRef.key .Values.global.postgresPasswordSecretKeyRef.key) }}
   {{- else }}
@@ -190,18 +190,18 @@ POSTGRES_PASSWORD env var secret key
 {{- /*
 POSTGRES_USER env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.postgres-user-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.postgres-user-env-var-secret-name" }}
   {{- if or .Values.postgresUserSecretKeyRef .Values.global.postgresUserSecretKeyRef }}
 {{- printf (coalesce .Values.postgresUserSecretKeyRef.name .Values.global.postgresUserSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 POSTGRES_USER env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.postgres-user-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.postgres-user-env-var-secret-key" }}
   {{- if or .Values.postgresUserSecretKeyRef .Values.global.postgresUserSecretKeyRef }}
 {{- printf (coalesce .Values.postgresUserSecretKeyRef.key .Values.global.postgresUserSecretKeyRef.key) }}
   {{- else }}
@@ -212,18 +212,18 @@ POSTGRES_USER env var secret key
 {{- /*
 RABBITMQ_HOSTNAME env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.rabbitmq-hostname-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.rabbitmq-hostname-env-var-secret-name" }}
   {{- if or .Values.rabbitmqHostnameSecretKeyRef .Values.global.rabbitmqHostnameSecretKeyRef }}
 {{- printf (coalesce .Values.rabbitmqHostnameSecretKeyRef.name .Values.global.rabbitmqHostnameSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 RABBITMQ_HOSTNAME env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.rabbitmq-hostname-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.rabbitmq-hostname-env-var-secret-key" }}
   {{- if or .Values.rabbitmqHostnameSecretKeyRef .Values.global.rabbitmqHostnameSecretKeyRef }}
 {{- printf (coalesce .Values.rabbitmqHostnameSecretKeyRef.key .Values.global.rabbitmqHostnameSecretKeyRef.key) }}
   {{- else }}
@@ -234,18 +234,18 @@ RABBITMQ_HOSTNAME env var secret key
 {{- /*
 RABBITMQ_PASSWORD env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.rabbitmq-password-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.rabbitmq-password-env-var-secret-name" }}
   {{- if or .Values.rabbitmqPasswordSecretKeyRef .Values.global.rabbitmqPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.rabbitmqPasswordSecretKeyRef.name .Values.global.rabbitmqPasswordSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 RABBITMQ_PASSWORD env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.rabbitmq-password-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.rabbitmq-password-env-var-secret-key" }}
   {{- if or .Values.rabbitmqPasswordSecretKeyRef .Values.global.rabbitmqPasswordSecretKeyRef }}
 {{- printf (coalesce .Values.rabbitmqPasswordSecretKeyRef.key .Values.global.rabbitmqPasswordSecretKeyRef.key) }}
   {{- else }}
@@ -256,18 +256,18 @@ RABBITMQ_PASSWORD env var secret key
 {{- /*
 RABBITMQ_USERNAME env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.rabbitmq-username-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.rabbitmq-username-env-var-secret-name" }}
   {{- if or .Values.rabbitmqUsernameSecretKeyRef .Values.global.rabbitmqUsernameSecretKeyRef }}
 {{- printf (coalesce .Values.rabbitmqUsernameSecretKeyRef.name .Values.global.rabbitmqUsernameSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 RABBITMQ_USERNAME env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.rabbitmq-username-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.rabbitmq-username-env-var-secret-key" }}
   {{- if or .Values.rabbitmqUsernameSecretKeyRef .Values.global.rabbitmqUsernameSecretKeyRef }}
 {{- printf (coalesce .Values.rabbitmqUsernameSecretKeyRef.key .Values.global.rabbitmqUsernameSecretKeyRef.key) }}
   {{- else }}
@@ -278,18 +278,18 @@ RABBITMQ_USERNAME env var secret key
 {{- /*
 FIREBASE_SECRET env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.firebase-secret-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.firebase-secret-env-var-secret-name" }}
   {{- if or .Values.firebaseSecretSecretKeyRef .Values.global.firebaseSecretSecretKeyRef }}
 {{- printf (coalesce .Values.firebaseSecretSecretKeyRef.name .Values.global.firebaseSecretSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 FIREBASE_SECRET env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.firebase-secret-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.firebase-secret-env-var-secret-key" }}
   {{- if or .Values.firebaseSecretSecretKeyRef .Values.global.firebaseSecretSecretKeyRef }}
 {{- printf (coalesce .Values.firebaseSecretSecretKeyRef.key .Values.global.firebaseSecretSecretKeyRef.key) }}
   {{- else }}
@@ -300,18 +300,18 @@ FIREBASE_SECRET env var secret key
 {{- /*
 FIREBASE_URL env var secret name
 */}}
-{{- define "cf-common-0.25.0.classic.firebase-url-env-var-secret-name" }}
+{{- define "cf-common-0.26.0.classic.firebase-url-env-var-secret-name" }}
   {{- if or .Values.firebaseUrlSecretKeyRef .Values.global.firebaseUrlSecretKeyRef }}
 {{- printf (coalesce .Values.firebaseUrlSecretKeyRef.name .Values.global.firebaseUrlSecretKeyRef.name) }}
   {{- else }}
-{{- printf "%s-%s" (include "cf-common-0.25.0.names.fullname" .) "secret" }}
+{{- printf "%s-%s" (include "cf-common-0.26.0.names.fullname" .) "secret" }}
   {{- end }}
 {{- end }}
 
 {{- /*
 FIREBASE_URL env var secret key
 */}}
-{{- define "cf-common-0.25.0.classic.firebase-url-env-var-secret-key" }}
+{{- define "cf-common-0.26.0.classic.firebase-url-env-var-secret-key" }}
   {{- if or .Values.firebaseUrlSecretKeyRef .Values.global.firebaseUrlSecretKeyRef }}
 {{- printf (coalesce .Values.firebaseUrlSecretKeyRef.key .Values.global.firebaseUrlSecretKeyRef.key) }}
   {{- else }}

--- a/charts/cf-common/templates/classic/_helpers.tpl
+++ b/charts/cf-common/templates/classic/_helpers.tpl
@@ -2,10 +2,10 @@
 Calculate RabbitMQ URI (for On-Prem)
 Must me called from chart root context.
 Usage:
-{{ include "cf-common-0.25.0.classic.calculateRabbitMqUri" . }}
+{{ include "cf-common-0.26.0.classic.calculateRabbitMqUri" . }}
 */}}
 
-{{- define "cf-common-0.25.0.classic.calculateRabbitMqUri" }}
+{{- define "cf-common-0.26.0.classic.calculateRabbitMqUri" }}
 
 {{- $rabbitmqProtocol := .Values.global.rabbitmqProtocol | default "amqp" -}}
 {{- $rabbitmqUsername := .Values.global.rabbitmqUsername -}}
@@ -23,9 +23,9 @@ coalesce here for backward compatibility
 {{/*
 Calculate Mongo Uri (for On-Prem)
 Usage:
-{{ include "cf.common-0.25.0.classic.calculateMongoUri" (dict "dbName" $.Values.global.pipelineManagerService "mongoURI" $.Values.global.mongoURI) }}
+{{ include "cf.common-0.26.0.classic.calculateMongoUri" (dict "dbName" $.Values.global.pipelineManagerService "mongoURI" $.Values.global.mongoURI) }}
 */}}
-{{- define "cf-common-0.25.0.classic.calculateMongoUri" -}}
+{{- define "cf-common-0.26.0.classic.calculateMongoUri" -}}
   {{- if contains "?" .mongoURI -}}
     {{- $mongoURI :=  (splitList "?" .mongoURI) -}}
     {{- printf "%s%s?%s" (first $mongoURI) .dbName (last $mongoURI) }}
@@ -39,7 +39,7 @@ Usage:
 {{/*
 Calculate Consul host Uri (for On-Prem)
 */}}
-{{- define "cf-common-0.25.0.classic.calculateConsulUri" }}
+{{- define "cf-common-0.26.0.classic.calculateConsulUri" }}
 	{{- if .Values.global.consulHost }}
 	{{- printf "http://%s:%v" .Values.global.consulHost .Values.global.consulHttpPort -}}
 	{{- else }}

--- a/charts/cf-common/templates/common/_annotations.tpl
+++ b/charts/cf-common/templates/common/_annotations.tpl
@@ -2,19 +2,19 @@
 Render checksum annotation
 Must be called from chart root context.
 Usage:
-annotations: {{ include "cf-common-0.25.0.annotations.podAnnotations" . | nindent }}
+annotations: {{ include "cf-common-0.26.0.annotations.podAnnotations" . | nindent }}
 */}}
-{{- define "cf-common-0.25.0.annotations.podAnnotations" -}}
+{{- define "cf-common-0.26.0.annotations.podAnnotations" -}}
 
 {{- if .Values.podAnnotations -}}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 0 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 0 }}
 {{- end -}}
 
 {{- $configMapFound := dict -}}
 {{- range $configMapIndex, $configMapItem := .Values.configMaps -}}
 
   {{- if $configMapItem.enabled -}}
-    {{- $_ := set $configMapFound $configMapIndex ( include "cf-common-0.25.0.tplrender" (dict "Values" $configMapItem.data "context" $) | sha256sum) -}}
+    {{- $_ := set $configMapFound $configMapIndex ( include "cf-common-0.26.0.tplrender" (dict "Values" $configMapItem.data "context" $) | sha256sum) -}}
   {{- end -}}
 
   {{- if $configMapFound -}}
@@ -27,7 +27,7 @@ annotations: {{ include "cf-common-0.25.0.annotations.podAnnotations" . | ninden
 {{- range $secretIndex, $secretItem := .Values.secrets -}}
 
   {{- if $secretItem.enabled -}}
-    {{- $_ := set $secretFound $secretIndex ( include "cf-common-0.25.0.tplrender" (dict "Values" $secretItem.stringData "context" $) | sha256sum) -}}
+    {{- $_ := set $secretFound $secretIndex ( include "cf-common-0.26.0.tplrender" (dict "Values" $secretItem.stringData "context" $) | sha256sum) -}}
   {{- end -}}
 
   {{- if $secretFound -}}

--- a/charts/cf-common/templates/common/_labels.tpl
+++ b/charts/cf-common/templates/common/_labels.tpl
@@ -1,9 +1,9 @@
 {{/*
 Kubernetes standard labels
 */}}
-{{- define "cf-common-0.25.0.labels.standard" -}}
-app.kubernetes.io/name: {{ include "cf-common-0.25.0.names.name" . }}
-helm.sh/chart: {{ include "cf-common-0.25.0.names.chart" . }}
+{{- define "cf-common-0.26.0.labels.standard" -}}
+app.kubernetes.io/name: {{ include "cf-common-0.26.0.names.name" . }}
+helm.sh/chart: {{ include "cf-common-0.26.0.names.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
@@ -11,11 +11,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
 */}}
-{{- define "cf-common-0.25.0.labels.matchLabels" -}}
-app.kubernetes.io/name: {{ include "cf-common-0.25.0.names.name" . }}
+{{- define "cf-common-0.26.0.labels.matchLabels" -}}
+app.kubernetes.io/name: {{ include "cf-common-0.26.0.names.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.fullnameOverride }}
-app.kubernetes.io/component: {{ include "cf-common-0.25.0.names.fullname" . }}
+app.kubernetes.io/component: {{ include "cf-common-0.26.0.names.fullname" . }}
   {{- end }}
 {{- end -}}
 
@@ -23,9 +23,9 @@ app.kubernetes.io/component: {{ include "cf-common-0.25.0.names.fullname" . }}
 {{/*
 Extra labels
 Usage:
-{{ include "cf-common-0.25.0.labels.extraLabels" ( dict "Values" .Values.path.to.the.labels "context" $) }}
+{{ include "cf-common-0.26.0.labels.extraLabels" ( dict "Values" .Values.path.to.the.labels "context" $) }}
 */}}
-{{- define "cf-common-0.25.0.labels.extraLabels" -}}
+{{- define "cf-common-0.26.0.labels.extraLabels" -}}
   {{- if not (kindIs "map" .Values) -}}
   {{- fail "ERROR: labels block must be a map" -}}
   {{- end -}}
@@ -37,9 +37,9 @@ Usage:
 {{/*
 Annotations
 Usage:
-{{ include "cf-common-0.25.0.annotations" ( dict "Values" .Values.path.to.the.annotations "context" $) }}
+{{ include "cf-common-0.26.0.annotations" ( dict "Values" .Values.path.to.the.annotations "context" $) }}
 */}}
-{{- define "cf-common-0.25.0.annotations" -}}
+{{- define "cf-common-0.26.0.annotations" -}}
   {{- if not (kindIs "map" .Values) -}}
   {{- fail "ERROR: annotations block must be a map" -}}
   {{- end -}}

--- a/charts/cf-common/templates/common/_names.tpl
+++ b/charts/cf-common/templates/common/_names.tpl
@@ -1,14 +1,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "cf-common-0.25.0.names.name" -}}
+{{- define "cf-common-0.26.0.names.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "cf-common-0.25.0.names.chart" -}}
+{{- define "cf-common-0.26.0.names.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -17,7 +17,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "cf-common-0.25.0.names.fullname" -}}
+{{- define "cf-common-0.26.0.names.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -33,10 +33,10 @@ If release name contains chart name it will be used as a full name.
 {{/*
 ServiceAccount Name
 */}}
-{{- define "cf-common-0.25.0.names.serviceAccountName" -}}
+{{- define "cf-common-0.26.0.names.serviceAccountName" -}}
   {{- if .Values.serviceAccount -}}
     {{- if .Values.serviceAccount.enabled -}}
-      {{- .Values.serviceAccount.nameOverride | default (include "cf-common-0.25.0.names.fullname" .)  -}}
+      {{- .Values.serviceAccount.nameOverride | default (include "cf-common-0.26.0.names.fullname" .)  -}}
     {{- else -}}
       {{- print "default" -}}
     {{- end -}}

--- a/charts/cf-common/templates/common/_tpl.tpl
+++ b/charts/cf-common/templates/common/_tpl.tpl
@@ -1,9 +1,9 @@
 {{/*
 Renders a value that contains template.
 Usage:
-{{ include "cf-common-0.25.0.tplrender" ( dict "Values" .Values.path.to.the.Value "context" $) }}
+{{ include "cf-common-0.26.0.tplrender" ( dict "Values" .Values.path.to.the.Value "context" $) }}
 */}}
-{{- define "cf-common-0.25.0.tplrender" -}}
+{{- define "cf-common-0.26.0.tplrender" -}}
   {{- $tpl := .Values -}}
   {{- if not (typeIs "string" $tpl) -}}
     {{- $tpl = toYaml $tpl -}}

--- a/charts/cf-common/templates/common/_versions.tpl
+++ b/charts/cf-common/templates/common/_versions.tpl
@@ -1,21 +1,21 @@
 {{/*
 Return the target Kubernetes version
 */}}
-{{- define "cf-common-0.25.0.kubeVersion" -}}
+{{- define "cf-common-0.26.0.kubeVersion" -}}
 {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for HPA
 */}}
-{{- define "cf-common-0.25.0.apiVersion.autoscaling" -}}
+{{- define "cf-common-0.26.0.apiVersion.autoscaling" -}}
 {{- if .Values.apiVersionOverrides -}}
   {{- if .Values.apiVersionOverrides.autoscaling -}}
     {{- print .Values.apiVersionOverrides.autoscaling -}}
   {{- else -}}
     {{- print "autoscaling/v2" -}}
   {{- end -}}
-{{- else if semverCompare "<1.23-0" (include "cf-common-0.25.0.kubeVersion" . ) -}}
+{{- else if semverCompare "<1.23-0" (include "cf-common-0.26.0.kubeVersion" . ) -}}
   {{- print "autoscaling/v2beta2" -}}
 {{- else -}}
   {{- print "autoscaling/v2" -}}

--- a/charts/cf-common/templates/container/_container.tpl
+++ b/charts/cf-common/templates/container/_container.tpl
@@ -2,27 +2,27 @@
 Renders main container in pod template.
 Called from pod template.
 Usage:
-{{ include "cf-common-0.25.0.container" (dict "Values" .Values.container "context" $) }}
+{{ include "cf-common-0.26.0.container" (dict "Values" .Values.container "context" $) }}
 */}}
-{{-  define "cf-common-0.25.0.container" -}}
+{{-  define "cf-common-0.26.0.container" -}}
 
 {{/* Restoring root $ context */}}
 {{- $ := .context -}}
 
-{{- $containerName := include "cf-common-0.25.0.names.fullname" $ -}}
+{{- $containerName := include "cf-common-0.26.0.names.fullname" $ -}}
 {{- if and (hasKey .Values "nameOverride") .Values.nameOverride }}
-{{- $containerName = include "cf-common-0.25.0.tplrender" (dict "Values" .Values.nameOverride "context" $) -}}
+{{- $containerName = include "cf-common-0.26.0.tplrender" (dict "Values" .Values.nameOverride "context" $) -}}
 {{- end }}
 
 - name: {{ $containerName }}
-  image: {{ (include "cf-common-0.25.0.tplrender" (dict "Values" (include "cf-common-0.25.0.image.name" (dict "image" .Values.image "context" $)) "context" $)) }}
+  image: {{ (include "cf-common-0.26.0.tplrender" (dict "Values" (include "cf-common-0.26.0.image.name" (dict "image" .Values.image "context" $)) "context" $)) }}
   imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
 
   {{- with .Values.command }}
     {{- if not (kindIs "slice" .) }}
       {{- fail "ERROR: container.command block must be a list!" }}
     {{- end }}
-  command: {{- include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $) | nindent 2 }}
+  command: {{- include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $) | nindent 2 }}
   {{- end }}
 
   {{- with .Values.args }}
@@ -52,12 +52,12 @@ Usage:
       {{- if not (kindIs "slice" .) }}
         {{ fail "ERROR: container.envFrom block must be a list!"}}
       {{- end }}
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $) | trim | nindent 4 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $) | trim | nindent 4 }}
     {{- end }}
     {{- range $secretName, $secretItem := $.Values.secrets }}
       {{- if $secretItem.enabled }}
     - secretRef:
-        name: {{ printf "%s-%s" (include "cf-common-0.25.0.names.fullname" $) $secretName }}
+        name: {{ printf "%s-%s" (include "cf-common-0.26.0.names.fullname" $) $secretName }}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -74,15 +74,15 @@ For backward compatibility (.Values.env takes precedence over .Values.container.
   {{- $mergedEnv = merge $mergedEnv $.Values.global.env }}
     {{- end }}
   env:
-  {{- include "cf-common-0.25.0.env-vars" (dict "Values" $mergedEnv "context" $) | trim | nindent 2 }}
+  {{- include "cf-common-0.26.0.env-vars" (dict "Values" $mergedEnv "context" $) | trim | nindent 2 }}
   
     {{- if .Values.extraEnv }}
-  {{- include "cf-common-0.25.0.env-vars" (dict "Values" .Values.extraEnv "context" $) | trim | nindent 2 }}
+  {{- include "cf-common-0.26.0.env-vars" (dict "Values" .Values.extraEnv "context" $) | trim | nindent 2 }}
     {{- end }}
     
   {{- end }}
 
-  {{- include "cf-common-0.25.0.ports" $ | trim | nindent 2 }}
+  {{- include "cf-common-0.26.0.ports" $ | trim | nindent 2 }}
 
 {{- /*
 For backward compatibility (.Values.volumeMounts takes precedence over .Values.container.volumeMounts)
@@ -91,10 +91,10 @@ For backward compatibility (.Values.volumeMounts takes precedence over .Values.c
     {{- if $.Values.volumeMounts }}
   {{- $mergedVolumeMounts = mergeOverwrite $mergedVolumeMounts $.Values.volumeMounts }}
     {{- end }}
-  volumeMounts: {{ include "cf-common-0.25.0.volumeMounts" (dict "Values" $mergedVolumeMounts "context" $) | trim | nindent 2 }}
+  volumeMounts: {{ include "cf-common-0.26.0.volumeMounts" (dict "Values" $mergedVolumeMounts "context" $) | trim | nindent 2 }}
 
   {{- with .Values.probes }}
-  {{- include "cf-common-0.25.0.probes" . | trim | nindent 2 }}
+  {{- include "cf-common-0.26.0.probes" . | trim | nindent 2 }}
   {{- end }}
 
   {{- with .Values.resources }}

--- a/charts/cf-common/templates/container/_env_vars.tpl
+++ b/charts/cf-common/templates/container/_env_vars.tpl
@@ -2,9 +2,9 @@
 Renders env vars in container template.
 Called from container template.
 Usage:
-env: {{ include "cf-common-0.25.0.env-vars" (dict "Values" .Values.container.env "context" $) | nindent }}
+env: {{ include "cf-common-0.26.0.env-vars" (dict "Values" .Values.container.env "context" $) | nindent }}
 */}}
-{{- define "cf-common-0.25.0.env-vars"}}
+{{- define "cf-common-0.26.0.env-vars"}}
 {{- $ := .context }}
   {{- if .Values }}
     {{- if not (kindIs "map" .Values) }}
@@ -12,7 +12,7 @@ env: {{ include "cf-common-0.25.0.env-vars" (dict "Values" .Values.container.env
     {{- end }}
   {{- end }}
   {{- $env := .Values }}
-  {{- $templatedEnv := include "cf-common-0.25.0.tplrender" (dict "Values" $env "context" $) | fromYaml }}
+  {{- $templatedEnv := include "cf-common-0.26.0.tplrender" (dict "Values" $env "context" $) | fromYaml }}
   {{- range $name, $val := $templatedEnv }}
     {{- if or (kindIs "string" $val) (kindIs "bool" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
 - name: {{ $name }}

--- a/charts/cf-common/templates/container/_image.tpl
+++ b/charts/cf-common/templates/container/_image.tpl
@@ -2,9 +2,9 @@
 Prints full image name.
 Called from container template.
 Usage:
-{{ include "cf-common-0.25.0.image.name" (dict "image" .Values.container.image "context" $) }}
+{{ include "cf-common-0.26.0.image.name" (dict "image" .Values.container.image "context" $) }}
 */}}
-{{- define "cf-common-0.25.0.image.name" -}}
+{{- define "cf-common-0.26.0.image.name" -}}
 
 {{/* Restoring root $ context */}}
 {{- $ := .context -}}
@@ -68,9 +68,9 @@ For backward compatibility (onprem with private docker registry)
 Prints full image name.
 Must be called from chart root context.
 Usage:
-{{ include "cf-common-0.25.0.image.pullSecrets" . }}
+{{ include "cf-common-0.26.0.image.pullSecrets" . }}
 */}}
-{{- define "cf-common-0.25.0.image.pullSecrets" -}}
+{{- define "cf-common-0.26.0.image.pullSecrets" -}}
   {{- $pullSecrets := list }}
 
   {{- if .Values.global.imagePullSecrets }}
@@ -78,8 +78,14 @@ Usage:
     {{- fail "ERROR: imagePullSecrets block must be a list!" -}}
     {{- end -}}
 
-    {{- range .Values.global.imagePullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets (include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $)) -}}
+    {{- range $index, $pullSecret := .Values.global.imagePullSecrets -}}
+      {{- if and (kindIs "map" $pullSecret ) }}
+        {{- if and $pullSecret.name }}
+          {{- $pullSecrets = append $pullSecrets (include "cf-common-0.26.0.tplrender" (dict "Values" $pullSecret.name "context" $)) -}}
+        {{- end }}
+      {{- else }}
+        {{- $pullSecrets = append $pullSecrets (include "cf-common-0.26.0.tplrender" (dict "Values" $pullSecret "context" $)) -}}
+      {{- end }}
     {{- end -}}
   {{- end -}}
 
@@ -88,8 +94,14 @@ Usage:
     {{- fail "ERROR: imagePullSecrets block must be a list!" -}}
     {{- end -}}
 
-    {{- range .Values.imagePullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets (include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $)) -}}
+    {{- range $index, $pullSecret := .Values.imagePullSecrets -}}
+      {{- if and (kindIs "map" $pullSecret ) }}
+        {{- if and $pullSecret.name }}
+          {{- $pullSecrets = append $pullSecrets (include "cf-common-0.26.0.tplrender" (dict "Values" $pullSecret.name "context" $)) -}}
+        {{- end }}
+      {{- else }}
+        {{- $pullSecrets = append $pullSecrets (include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $)) -}}
+      {{- end }}
     {{- end -}}
   {{- end -}}
 

--- a/charts/cf-common/templates/container/_ports.tpl
+++ b/charts/cf-common/templates/container/_ports.tpl
@@ -2,10 +2,10 @@
 Renders ports map in container. Ports are obtained from .Values.service
 Called from container template.
 Usage:
-ports: {{- include "cf-common-0.25.0.ports" $ | nindent }}
+ports: {{- include "cf-common-0.26.0.ports" $ | nindent }}
 */}}
 
-{{- define "cf-common-0.25.0.ports" -}}
+{{- define "cf-common-0.26.0.ports" -}}
 
 {{- $ports := list -}}
 {{- range $serviceName, $serviceItem := .Values.service }}

--- a/charts/cf-common/templates/container/_probes.tpl
+++ b/charts/cf-common/templates/container/_probes.tpl
@@ -2,9 +2,9 @@
 Renders probes map in container.
 Called from container template.
 Usage:
-probes: {{ include "cf-common-0.25.0.probes" .Values.container.probes | nindent 2 }}
+probes: {{ include "cf-common-0.26.0.probes" .Values.container.probes | nindent 2 }}
 */}}
-{{- define "cf-common-0.25.0.probes" -}}
+{{- define "cf-common-0.26.0.probes" -}}
 
 {{- range $probeName, $probeItem := . }}
 

--- a/charts/cf-common/templates/container/_volumemounts.tpl
+++ b/charts/cf-common/templates/container/_volumemounts.tpl
@@ -2,10 +2,10 @@
 Renders volumeMounts list in container.
 Called from container template.
 Usage:
-volumeMounts: {{- include "cf-common-0.25.0.volumeMounts" (dict "Values" .Values.container.volumeMounts "context" $) | nindent 2 }}
+volumeMounts: {{- include "cf-common-0.26.0.volumeMounts" (dict "Values" .Values.container.volumeMounts "context" $) | nindent 2 }}
 */}}
 
-{{- define "cf-common-0.25.0.volumeMounts" -}}
+{{- define "cf-common-0.26.0.volumeMounts" -}}
 {{/* Restoring root $ context */}}
 {{- $ := .context -}}
 

--- a/charts/cf-common/templates/controller/_analysis-template.tpl
+++ b/charts/cf-common/templates/controller/_analysis-template.tpl
@@ -1,6 +1,6 @@
-{{- define "cf-common-0.25.0.controller.analysis-template" -}}
+{{- define "cf-common-0.26.0.controller.analysis-template" -}}
 
-{{- $fullName:= include "cf-common-0.25.0.names.fullname" . }}
+{{- $fullName:= include "cf-common-0.26.0.names.fullname" . }}
 
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -9,7 +9,7 @@ metadata:
   name: error-rate-{{ $fullName }}
 spec:
   {{- with .Values.controller.rollout.analysisTemplate }}
-  args: {{- include "cf-common-0.25.0.tplrender" (dict "Values" .args "context" $) | nindent 4 }}
+  args: {{- include "cf-common-0.26.0.tplrender" (dict "Values" .args "context" $) | nindent 4 }}
   metrics: {{- .metrics | toYaml | nindent 4 }}
   {{- end }}
 

--- a/charts/cf-common/templates/controller/_controller.tpl
+++ b/charts/cf-common/templates/controller/_controller.tpl
@@ -2,10 +2,10 @@
 Renders contoller object.
 Must be called from chart root context.
 Usage:
-{{- include "cf-common-0.25.0.controller" . -}}
+{{- include "cf-common-0.26.0.controller" . -}}
 */}}
 
-{{- define "cf-common-0.25.0.controller" -}}
+{{- define "cf-common-0.26.0.controller" -}}
 
 {{- if .Values.controller.enabled -}}
 
@@ -20,22 +20,22 @@ Usage:
   {{- $_ := set .Values "controller" (deepCopy $mergedControllerValues) -}}
 
   {{- if eq .Values.controller.type "rollout" }}
-    {{ include "cf-common-0.25.0.controller.rollout" . | nindent 0 }}
+    {{ include "cf-common-0.26.0.controller.rollout" . | nindent 0 }}
     {{- if .Values.controller.rollout }}
       {{- if .Values.controller.rollout.analysisTemplate }}
         {{- if .Values.controller.rollout.analysisTemplate.enabled }}
-      {{ include "cf-common-0.25.0.controller.analysis-template" . | nindent 0 }}
+      {{ include "cf-common-0.26.0.controller.analysis-template" . | nindent 0 }}
         {{- end }}
       {{- end }}
     {{- end }}
   {{- else if eq .Values.controller.type "deployment" }}
-    {{ include "cf-common-0.25.0.controller.deployment" . | nindent 0 }}
+    {{ include "cf-common-0.26.0.controller.deployment" . | nindent 0 }}
   {{- else if eq .Values.controller.type "statefulset" }}
-    {{ include "cf-common-0.25.0.controller.statefulset" . | nindent 0 }}
+    {{ include "cf-common-0.26.0.controller.statefulset" . | nindent 0 }}
   {{- else if eq .Values.controller.type "job" }}
-    {{ include "cf-common-0.25.0.controller.job" . | nindent 0 }}
+    {{ include "cf-common-0.26.0.controller.job" . | nindent 0 }}
   {{- else if eq .Values.controller.type "cronjob" }}
-    {{ include "cf-common-0.25.0.controller.cronjob" . | nindent 0 }}
+    {{ include "cf-common-0.26.0.controller.cronjob" . | nindent 0 }}
   {{- else }}
     {{ fail (printf "ERROR: %s is invalid controller type!" .Values.controller.type) }}
   {{- end }}

--- a/charts/cf-common/templates/controller/_cronjob.tpl
+++ b/charts/cf-common/templates/controller/_cronjob.tpl
@@ -2,23 +2,23 @@
 Renders cronjob template.
 Must be called from chart root context.
 Usage:
-{{ include "cf-common-0.25.0.controller.cronjob" . }}
+{{ include "cf-common-0.26.0.controller.cronjob" . }}
 */}}
 
-{{- define "cf-common-0.25.0.controller.cronjob" -}}
+{{- define "cf-common-0.26.0.controller.cronjob" -}}
 
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" . }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" . }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
   {{- if .Values.controller.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.controller.annotations }}
   annotations:
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   concurrencyPolicy: {{ .Values.controller.cronjob.concurrencyPolicy }}
@@ -45,15 +45,15 @@ spec:
       {{- end }}
       template:
         metadata:
-          labels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 12 }}
+          labels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 12 }}
           {{- if .Values.podLabels }}
-          {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 12 }}
+          {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 12 }}
           {{- end }}
-          {{- with include "cf-common-0.25.0.annotations.podAnnotations" . }}
+          {{- with include "cf-common-0.26.0.annotations.podAnnotations" . }}
           annotations:
             {{- . | nindent 12 }}
           {{- end }}
-        spec: {{- include "cf-common-0.25.0.controller.pod" . | trim | nindent 10 -}}
+        spec: {{- include "cf-common-0.26.0.controller.pod" . | trim | nindent 10 -}}
       {{- with .Values.controller.cronjob.ttlSecondsAfterFinished }}
       ttlSecondsAfterFinished: {{ . }}
       {{- end }}

--- a/charts/cf-common/templates/controller/_deployment.tpl
+++ b/charts/cf-common/templates/controller/_deployment.tpl
@@ -2,10 +2,10 @@
 Renders deployment template
 Must be called from chart root context.
 Usage:
-{{ include "cf-common-0.25.0.controller.deployment" . }}
+{{ include "cf-common-0.26.0.controller.deployment" . }}
 */}}
 
-{{- define "cf-common-0.25.0.controller.deployment" -}}
+{{- define "cf-common-0.26.0.controller.deployment" -}}
 
 {{- $controllerValues := deepCopy .Values.controller -}}
 {{- $deploymentValues := dict -}}
@@ -21,7 +21,7 @@ Usage:
   {{- fail (printf "ERROR: %s is invalid Deployment strategy!" $strategy) -}}
 {{- end -}}
 
-{{- $deploymentName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- $deploymentName := include "cf-common-0.26.0.names.fullname" . -}}
 {{- if and (hasKey .Values.controller "nameOverride") .Values.controller.nameOverride -}}
   {{- $deploymentName = printf "%v-%v" $deploymentName .Values.controller.nameOverride -}}
 {{- end -}}
@@ -31,13 +31,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $deploymentName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
   {{- if .Values.controller.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.controller.annotations }}
   annotations:
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit | int | default 5 }}
@@ -45,7 +45,7 @@ spec:
   replicas: {{ coalesce .Values.controller.replicas .Values.replicaCount | int | default 1 }}
   {{- end }}
   selector:
-    matchLabels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 6 }}
   strategy:
     type: {{ $strategy }}
     {{- with .Values.controller.rollingUpdate }}
@@ -61,13 +61,13 @@ spec:
     {{- end }}
   template:
     metadata:
-      labels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 8 }}
+      labels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 8 }}
       {{- if .Values.podLabels }}
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-    spec: {{- include "cf-common-0.25.0.controller.pod" . | trim | nindent 6 -}}
+    spec: {{- include "cf-common-0.26.0.controller.pod" . | trim | nindent 6 -}}
 {{- end -}}

--- a/charts/cf-common/templates/controller/_job.tpl
+++ b/charts/cf-common/templates/controller/_job.tpl
@@ -2,23 +2,23 @@
 Renders job template.
 Must be called from chart root context.
 Usage:
-{{ include "cf-common-0.25.0.controller.job" . }}
+{{ include "cf-common-0.26.0.controller.job" . }}
 */}}
 
-{{- define "cf-common-0.25.0.controller.job" -}}
+{{- define "cf-common-0.26.0.controller.job" -}}
 
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" . }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" . }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
   {{- if .Values.controller.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.controller.annotations }}
   annotations:
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.controller.job.suspend }}
@@ -40,22 +40,22 @@ spec:
   manualSelector: {{ .Values.controller.job.manualSelector }}
     {{- if .Values.controller.job.selector }}
   selector:
-    matchLabels: {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.job.selector "context" $) | nindent 6 }}
+    matchLabels: {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.job.selector "context" $) | nindent 6 }}
     {{- else }}
     {{ fail (printf "ERROR: manualSelector is enabled! Specify `.job.selector` labels!") }}
     {{- end }}
   {{- end }}
   template:
     metadata:
-      labels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 8 }}
+      labels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 8 }}
       {{- if .Values.podLabels }}
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
       {{- end }}
-      {{- with include "cf-common-0.25.0.annotations.podAnnotations" . }}
+      {{- with include "cf-common-0.26.0.annotations.podAnnotations" . }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
-    spec: {{- include "cf-common-0.25.0.controller.pod" . | trim | nindent 6 -}}
+    spec: {{- include "cf-common-0.26.0.controller.pod" . | trim | nindent 6 -}}
   {{- with .Values.controller.job.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ . }}
   {{- end }}

--- a/charts/cf-common/templates/controller/_pod.tpl
+++ b/charts/cf-common/templates/controller/_pod.tpl
@@ -2,13 +2,13 @@
 Renders pod spec.
 Called from contoller template.
 Usage:
-{{ include "cf-common-0.25.0.controller.pod" . }}
+{{ include "cf-common-0.26.0.controller.pod" . }}
 */}}
-{{- define "cf-common-0.25.0.controller.pod" -}}
+{{- define "cf-common-0.26.0.controller.pod" -}}
 
-{{- include "cf-common-0.25.0.image.pullSecrets" . }}
+{{- include "cf-common-0.26.0.image.pullSecrets" . }}
 
-serviceAccountName: {{ include "cf-common-0.25.0.names.serviceAccountName" . }}
+serviceAccountName: {{ include "cf-common-0.26.0.names.serviceAccountName" . }}
 
 automountServiceAccountToken: {{ .Values.automountServiceAccountToken | default true }}
 
@@ -58,22 +58,22 @@ initContainers:
   {{- range $initContainerIndex, $initContainerItem := .Values.initContainers }}
     {{- if $initContainerItem.enabled }}
     {{- $_ := set $initContainerItem "nameOverride" $initContainerIndex }}
-    {{- include "cf-common-0.25.0.container" (dict "Values" $initContainerItem "context" $) | trim | nindent 0 }}
+    {{- include "cf-common-0.26.0.container" (dict "Values" $initContainerItem "context" $) | trim | nindent 0 }}
     {{- end }}
   {{- end }}
 {{- end }}
 
 {{- with .Values.container }}
-containers: {{ include "cf-common-0.25.0.container" (dict "Values" . "context" $) | trim | nindent 0 }}
+containers: {{ include "cf-common-0.26.0.container" (dict "Values" . "context" $) | trim | nindent 0 }}
 {{- end }}
 {{- with .Values.additionalContainers }}
 {{ toYaml . | nindent 0 }}
 {{- end }}
 
-volumes:  {{ include "cf-common-0.25.0.volumes" (dict "Values" .Values.volumes "context" $) | trim | nindent 0 }}
+volumes:  {{ include "cf-common-0.26.0.volumes" (dict "Values" .Values.volumes "context" $) | trim | nindent 0 }}
 
 {{- with .Values.extraVolumes }}
-{{ include "cf-common-0.25.0.volumes" (dict "Values" . "context" $) | trim }}
+{{ include "cf-common-0.26.0.volumes" (dict "Values" . "context" $) | trim }}
 {{- end }}
 
 {{- with .Values.hostAliases }}
@@ -108,7 +108,7 @@ affinity: {{ toYaml . | nindent 2 }}
 {{- end }}
 
 {{- with .Values.topologySpreadConstraints }}
-topologySpreadConstraints: {{- include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $) | nindent 2 }}
+topologySpreadConstraints: {{- include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $) | nindent 2 }}
 {{- end }}
 
 {{- with .Values.controller.restartPolicy }}

--- a/charts/cf-common/templates/controller/_rollout.tpl
+++ b/charts/cf-common/templates/controller/_rollout.tpl
@@ -2,11 +2,11 @@
 Renders rollout template.
 Must be called from chart root context.
 Usage:
-{{ include "cf-common-0.25.0.controller.rollout" . }}
+{{ include "cf-common-0.26.0.controller.rollout" . }}
 */}}
-{{- define "cf-common-0.25.0.controller.rollout" -}}
+{{- define "cf-common-0.26.0.controller.rollout" -}}
 
-{{- $fullName:= include "cf-common-0.25.0.names.fullname" . }}
+{{- $fullName:= include "cf-common-0.26.0.names.fullname" . }}
 
 {{- $controllerValues := deepCopy .Values.controller -}}
 {{- $rolloutValues := dict -}}
@@ -22,7 +22,7 @@ Usage:
   {{- fail (printf "ERROR: %s is invalid Rollout strategy!" $strategy) -}}
 {{- end -}}
 
-{{- $rolloutName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- $rolloutName := include "cf-common-0.26.0.names.fullname" . -}}
 {{- if and (hasKey .Values.controller "nameOverride") .Values.controller.nameOverride -}}
   {{- $rolloutName = printf "%v-%v" $rolloutName .Values.controller.nameOverride -}}
 {{- end -}}
@@ -32,13 +32,13 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   name: {{ $rolloutName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
   {{- if .Values.controller.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.controller.annotations }}
   annotations:
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit | int | default 5 }}
@@ -46,7 +46,7 @@ spec:
   replicas: {{ coalesce .Values.controller.replicas .Values.replicaCount | int | default 1 }}
   {{- end }}
   selector:
-    matchLabels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 6 }}
     {{- with .Values.controller.rollout }}
   analysis: {{ .analysis | toYaml | nindent 4 }}
     {{- end }}
@@ -75,13 +75,13 @@ spec:
     {{- end }}
   template:
     metadata:
-      labels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 8 }}
+      labels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 8 }}
       {{- if .Values.podLabels }}
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-    spec: {{- include "cf-common-0.25.0.controller.pod" . | trim | nindent 6 -}}
+    spec: {{- include "cf-common-0.26.0.controller.pod" . | trim | nindent 6 -}}
 {{- end -}}

--- a/charts/cf-common/templates/controller/_statefulset.tpl
+++ b/charts/cf-common/templates/controller/_statefulset.tpl
@@ -2,10 +2,10 @@
 Renders statefulset template
 Must be called from chart root context.
 Usage:
-{{ include "cf-common-0.25.0.controller.statefulset" . }}
+{{ include "cf-common-0.26.0.controller.statefulset" . }}
 */}}
 
-{{- define "cf-common-0.25.0.controller.statefulset" -}}
+{{- define "cf-common-0.26.0.controller.statefulset" -}}
 
 {{/*Merge .Values.controller with .Values.controller.statefulset*/}}
 {{- $controllerValues := deepCopy .Values.controller -}}
@@ -27,7 +27,7 @@ Usage:
   {{- fail (printf "ERROR: %s is invalid Stateful Set podManagementPolicy!" $podManagementPolicy) -}}
 {{- end -}}
 
-{{- $stsName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- $stsName := include "cf-common-0.26.0.names.fullname" . -}}
 {{- if and (hasKey .Values.controller "nameOverride") .Values.controller.nameOverride -}}
   {{- $stsName = printf "%v-%v" $stsName .Values.controller.nameOverride -}}
 {{- end -}}
@@ -37,21 +37,21 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ $stsName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
   {{- if .Values.controller.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.controller.annotations }}
   annotations:
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.controller.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit | int | default 5 }}
   replicas: {{ coalesce .Values.controller.replicas .Values.replicaCount | int | default 1 }}
   podManagementPolicy: {{ default "OrderedReady" .Values.controller.podManagementPolicy }}
   selector:
-    matchLabels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 6 }}
-  serviceName: {{ include "cf-common-0.25.0.names.fullname" . }}
+    matchLabels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 6 }}
+  serviceName: {{ include "cf-common-0.26.0.names.fullname" . }}
   updateStrategy:
     type: {{ $strategy }}
     {{- with .Values.controller.rollingUpdate }}
@@ -62,25 +62,25 @@ spec:
     {{- end }}
   template:
     metadata:
-      labels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 8 }}
+      labels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 8 }}
       {{- if .Values.podLabels }}
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podLabels "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
-      {{- include "cf-common-0.25.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- include "cf-common-0.26.0.tplrender" (dict "Values" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-    spec: {{- include "cf-common-0.25.0.controller.pod" . | trim | nindent 6 }}
+    spec: {{- include "cf-common-0.26.0.controller.pod" . | trim | nindent 6 }}
   volumeClaimTemplates:
   {{- range $claimIndex, $claimItem := .Values.volumeClaimTemplates }}
     {{- if not (eq $claimItem.enabled false ) }}
     - metadata:
         name: {{ $claimIndex }}
         {{- with ($claimItem.labels | default dict) }}
-        labels: {{- include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $) | nindent 10 }}
+        labels: {{- include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $) | nindent 10 }}
         {{- end }}
         {{- with ($claimItem.annotations | default dict) }}
-        annotations: {{- include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $) | nindent 10 }}
+        annotations: {{- include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $) | nindent 10 }}
         {{- end }}
       spec:
         {{- $claimSize := required (printf "size is required for PVC %v" $claimItem.name) $claimItem.size }}
@@ -89,7 +89,7 @@ spec:
         resources:
           requests:
             storage: {{ $claimSize | quote }}
-        {{ include "cf-common-0.25.0.storageclass" ( dict "persistence" $claimItem "context" $) }}
+        {{ include "cf-common-0.26.0.storageclass" ( dict "persistence" $claimItem "context" $) }}
       {{- end }}
     {{- end }}
 {{- end -}}

--- a/charts/cf-common/templates/controller/_volumes.tpl
+++ b/charts/cf-common/templates/controller/_volumes.tpl
@@ -2,10 +2,10 @@
 Renders volumes in controller template.
 Called from pod template.
 Usage:
-volumes: {{ include "cf-common-0.25.0.volumes" (dict "Values" .Values.volumes "context" $) | nindent }}
+volumes: {{ include "cf-common-0.26.0.volumes" (dict "Values" .Values.volumes "context" $) | nindent }}
 */}}
 
-{{- define "cf-common-0.25.0.volumes" -}}
+{{- define "cf-common-0.26.0.volumes" -}}
 {{/* Restoring root $ context */}}
 {{- $ := .context -}}
 
@@ -26,10 +26,10 @@ volumes: {{ include "cf-common-0.25.0.volumes" (dict "Values" .Values.volumes "c
 
   {{- if $volumeItem.enabled }}
 - name: {{ $volumeIndex }}
-  {{- $volumeName := printf "%s-%s" (include "cf-common-0.25.0.names.fullname" $) $volumeIndex -}}
+  {{- $volumeName := printf "%s-%s" (include "cf-common-0.26.0.names.fullname" $) $volumeIndex -}}
 
   {{- if and (or (hasKey $volumeItem "existingName") (hasKey $volumeItem "nameOverride")) (or $volumeItem.existingName $volumeItem.nameOverride) }}
-  {{- $volumeName = include "cf-common-0.25.0.tplrender" (dict "Values" (coalesce $volumeItem.nameOverride $volumeItem.existingName) "context" $) -}}
+  {{- $volumeName = include "cf-common-0.26.0.tplrender" (dict "Values" (coalesce $volumeItem.nameOverride $volumeItem.existingName) "context" $) -}}
   {{- end }}
 
   {{- if eq $volumeItem.type "configMap" }}

--- a/charts/cf-common/templates/external-secrets/_external-secrets.tpl
+++ b/charts/cf-common/templates/external-secrets/_external-secrets.tpl
@@ -1,4 +1,4 @@
-{{- define "cf-common-0.25.0.external-secrets" }}
+{{- define "cf-common-0.26.0.external-secrets" }}
   {{- range $i, $secret := .Values.externalSecrets }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/charts/cf-common/templates/ingress/_ingress.tpl
+++ b/charts/cf-common/templates/ingress/_ingress.tpl
@@ -1,9 +1,9 @@
 {{/*
 Iterates over Ingress objects and calls render template.
 Must be called from chart root context.
-{{- include "cf-common-0.25.0.ingress" . -}}
+{{- include "cf-common-0.26.0.ingress" . -}}
 */}}
-{{- define "cf-common-0.25.0.ingress" -}}
+{{- define "cf-common-0.26.0.ingress" -}}
   {{- $primary := "" -}}
   {{- range $name, $ingress := .Values.ingress -}}
     {{- if and (hasKey $ingress "primary") $ingress.primary $ingress.enabled -}}
@@ -26,7 +26,7 @@ Must be called from chart root context.
 
       {{- $_ := set $ingressValues "name" $name -}}
       {{- $_ := set $ "ObjectValues" (dict "ingress" $ingressValues) -}}
-      {{- include "cf-common-0.25.0.ingress.render" $ | nindent 0 -}}
+      {{- include "cf-common-0.26.0.ingress.render" $ | nindent 0 -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -35,8 +35,8 @@ Must be called from chart root context.
 Renders Ingress objects.
 Called from the template above.
 */}}
-{{- define "cf-common-0.25.0.ingress.render" -}}
-  {{- $fullName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- define "cf-common-0.26.0.ingress.render" -}}
+  {{- $fullName := include "cf-common-0.26.0.names.fullname" . -}}
   {{- $ingressName := $fullName -}}
   {{- $ingressItem := .Values.ingress -}}
 
@@ -53,24 +53,24 @@ Called from the template above.
   {{- $defaultServiceName := $fullName -}}
   {{- $defaultServicePort := dict -}}
   {{- if .Values.service -}}
-    {{- $primaryService := get .Values.service (include "cf-common-0.25.0.service.primary" (dict "values" .Values.service)) -}}
-    {{- $defaultServicePort = get $primaryService.ports (include "cf-common-0.25.0.service.primaryPort" (dict "values" $primaryService)) -}}
+    {{- $primaryService := get .Values.service (include "cf-common-0.26.0.service.primary" (dict "values" .Values.service)) -}}
+    {{- $defaultServicePort = get $primaryService.ports (include "cf-common-0.26.0.service.primaryPort" (dict "values" $primaryService)) -}}
   {{- end -}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $ingressName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" $ | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" $ | nindent 4 }}
   {{- if $ingressItem.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $ingressItem.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $ingressItem.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if $ingressItem.annotations }}
-  annotations: {{- include "cf-common-0.25.0.tplrender" (dict "Values" $ingressItem.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "cf-common-0.26.0.tplrender" (dict "Values" $ingressItem.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   {{- if $ingressItem.ingressClassName }}
-  ingressClassName: {{ include "cf-common-0.25.0.tplrender" (dict "Values" $ingressItem.ingressClassName "context" $) }}
+  ingressClassName: {{ include "cf-common-0.26.0.tplrender" (dict "Values" $ingressItem.ingressClassName "context" $) }}
   {{- end }}
   {{- if $ingressItem.tls }}
   tls:
@@ -80,10 +80,10 @@ spec:
     {{- range $ingressItem.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $) | quote }}
+        - {{ include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $) | quote }}
         {{- end }}
       {{- if .secretName }}
-      secretName: {{ include "cf-common-0.25.0.tplrender" (dict "Values" .secretName "context" $) | quote}}
+      secretName: {{ include "cf-common-0.26.0.tplrender" (dict "Values" .secretName "context" $) | quote}}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -92,7 +92,7 @@ spec:
       {{- fail (printf "ERROR: ingress.%s.hosts must be a list!" $ingressItem.name) }}
     {{- end }}
   {{- range $ingressItem.hosts }}
-    - host: {{ include "cf-common-0.25.0.tplrender" (dict "Values" .host "context" $) | quote }}
+    - host: {{ include "cf-common-0.26.0.tplrender" (dict "Values" .host "context" $) | quote }}
       http:
         paths:
           {{- if not (kindIs "slice" .paths) }}
@@ -105,13 +105,13 @@ spec:
               {{- $service = default $service .service.name -}}
               {{- $port = default $port .service.port -}}
             {{- end }}
-          - path: {{ include "cf-common-0.25.0.tplrender" (dict "Values" .path "context" $) | quote }}
+          - path: {{ include "cf-common-0.26.0.tplrender" (dict "Values" .path "context" $) | quote }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             backend:
               service:
-                name: {{ include "cf-common-0.25.0.tplrender" (dict "Values" $service "context" $) }}
+                name: {{ include "cf-common-0.26.0.tplrender" (dict "Values" $service "context" $) }}
                 port:
-                  number: {{ include "cf-common-0.25.0.tplrender" (dict "Values" $port "context" $) }}
+                  number: {{ include "cf-common-0.26.0.tplrender" (dict "Values" $port "context" $) }}
           {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/cf-common/templates/ingress/_primary.tpl
+++ b/charts/cf-common/templates/ingress/_primary.tpl
@@ -2,9 +2,9 @@
 Return the name of the primary ingress object.
 Called from ingress template.
 Usage:
-{{ include "cf-common-0.25.0.ingress.primary" (dict "values" .Values.ingress ) }}
+{{ include "cf-common-0.26.0.ingress.primary" (dict "values" .Values.ingress ) }}
 */}}
-{{- define "cf-common-0.25.0.ingress.primary" -}}
+{{- define "cf-common-0.26.0.ingress.primary" -}}
   {{- $result := "" -}}
   {{- range $name, $ingress := .values -}}
     {{- if and (hasKey $ingress "primary") $ingress.primary $ingress.enabled -}}

--- a/charts/cf-common/templates/keda/_scaledobject.tpl
+++ b/charts/cf-common/templates/keda/_scaledobject.tpl
@@ -1,24 +1,24 @@
-{{- define "cf-common-0.25.0.keda.scaled-object" }}
+{{- define "cf-common-0.26.0.keda.scaled-object" }}
 {{- if .Values.keda.enabled }}
 
 {{- if and .Values.hpa.enabled }}
 {{- fail "ERROR: Both KEDA ScaledObject and HPA are enabled. Disable HPA or Keda ScaledObject!" }}
 {{- end }}
 
-{{- $controllerName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- $controllerName := include "cf-common-0.26.0.names.fullname" . -}}
   {{- if and (hasKey .Values.controller "nameOverride") .Values.controller.nameOverride -}}
     {{- $controllerName = printf "%v-%v" $controllerName .Values.controller.nameOverride -}}
   {{- end -}}
-{{- $containerName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- $containerName := include "cf-common-0.26.0.names.fullname" . -}}
   {{- if and (hasKey .Values.container "nameOverride") .Values.container.nameOverride }}
-    {{- $containerName = include "cf-common-0.25.0.tplrender" (dict "Values" .Values.container.nameOverride "context" .) -}}
+    {{- $containerName = include "cf-common-0.26.0.tplrender" (dict "Values" .Values.container.nameOverride "context" .) -}}
   {{- end }}
 
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" . }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" . }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
   annotations:
   {{- with .Values.keda.spec.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -56,7 +56,7 @@ spec:
   advanced:
     restoreToOriginalReplicaCount: {{ .restoreToOriginalReplicaCount | default false }}
     horizontalPodAutoscalerConfig:
-      name: {{ include "cf-common-0.25.0.names.fullname" . }}
+      name: {{ include "cf-common-0.26.0.names.fullname" . }}
       {{- with .horizontalPodAutoscalerConfig }}
         {{- toYaml . | nindent 6 }}
       {{- end -}}
@@ -70,7 +70,7 @@ spec:
     {{- end }}
     {{- if and $.Values.keda.auth.enabled }}
     authenticationRef:
-      name: {{ include "cf-common-0.25.0.names.fullname" $ }}
+      name: {{ include "cf-common-0.26.0.names.fullname" $ }}
     {{- end }}
   {{ end }}
 {{- end }}

--- a/charts/cf-common/templates/keda/_triggerauthentication.tpl
+++ b/charts/cf-common/templates/keda/_triggerauthentication.tpl
@@ -1,10 +1,10 @@
-{{- define "cf-common-0.25.0.keda.trigger-authentication" }}
+{{- define "cf-common-0.26.0.keda.trigger-authentication" }}
   {{- if and .Values.keda.auth.enabled .Values.keda.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" . }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" . }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
 spec:
   secretTargetRef: {{ toYaml .Values.keda.auth.secretTargetRef | nindent 4 }}
   {{- end }}

--- a/charts/cf-common/templates/persistence/_pvc.tpl
+++ b/charts/cf-common/templates/persistence/_pvc.tpl
@@ -2,33 +2,33 @@
 Renders PersistentVolumeClaim objects.
 Must be called from chart root context.
 Usage:
-{{- include "cf-common-0.25.0.pvc" . -}}
+{{- include "cf-common-0.26.0.pvc" . -}}
 */}}
-{{- define "cf-common-0.25.0.pvc" -}}
+{{- define "cf-common-0.26.0.pvc" -}}
 
 {{- range $pvcIndex, $pvcItem := .Values.persistence }}
 
 {{- if and (not $pvcItem.existingClaim) (eq (default "pvc" $pvcItem.type) "pvc") $pvcItem.enabled  }}
-{{- $pvcName := printf "%s-%s" (include "cf-common-0.25.0.names.fullname" $) $pvcIndex }}
+{{- $pvcName := printf "%s-%s" (include "cf-common-0.26.0.names.fullname" $) $pvcIndex }}
 
 {{- if and (hasKey $pvcItem "nameOverride") $pvcItem.nameOverride  }}
-{{- $pvcName = include "cf-common-0.25.0.tplrender" (dict "Values" $pvcItem.nameOverride "context" $) }}
+{{- $pvcName = include "cf-common-0.26.0.tplrender" (dict "Values" $pvcItem.nameOverride "context" $) }}
 {{- end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ $pvcName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" $ | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" $ | nindent 4 }}
   {{- if $pvcItem.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $pvcItem.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $pvcItem.labels "context" $) | nindent 4 }}
   {{- end }}
   annotations:
   {{- if $pvcItem.retain }}
     "helm.sh/resource-policy": keep
   {{- end }}
   {{- if $pvcItem.annotations }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $pvcItem.annotations "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $pvcItem.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   {{- $pvcSize := required (printf "size is required for PVC %v" $pvcName) $pvcItem.size }}
@@ -37,7 +37,7 @@ spec:
   resources:
     requests:
       storage: {{ $pvcSize | quote }}
-  {{ include "cf-common-0.25.0.storageclass" ( dict "persistence" $pvcItem "context" $) }}
+  {{ include "cf-common-0.26.0.storageclass" ( dict "persistence" $pvcItem "context" $) }}
   {{- if $pvcItem.volumeName }}
   volumeName: {{ $pvcItem.volumeName | quote }}
   {{- end }}

--- a/charts/cf-common/templates/persistence/_storage.tpl
+++ b/charts/cf-common/templates/persistence/_storage.tpl
@@ -1,9 +1,9 @@
 {{/*
 Return  the proper Storage Class.
 Called from pvc template. Root $ context must be passed.
-{{ include "cf-common-0.25.0.storageclass" ( dict "persistence" .Values.persistence.data "context" $) }}
+{{ include "cf-common-0.26.0.storageclass" ( dict "persistence" .Values.persistence.data "context" $) }}
 */}}
-{{- define "cf-common-0.25.0.storageclass" -}}
+{{- define "cf-common-0.26.0.storageclass" -}}
 
 {{/* Restoring root $ context */}}
 {{- $ := .context -}}

--- a/charts/cf-common/templates/render/_all.tpl
+++ b/charts/cf-common/templates/render/_all.tpl
@@ -2,14 +2,14 @@
 Render all underlying templates
 */}}
 
-{{- define "cf-common-0.25.0.all" -}}
+{{- define "cf-common-0.26.0.all" -}}
 
-{{- include "cf-common-0.25.0.controller" . -}}
-{{- include "cf-common-0.25.0.service" . -}}
-{{- include "cf-common-0.25.0.configmaps" . -}}
-{{- include "cf-common-0.25.0.secrets" . -}}
-{{- include "cf-common-0.25.0.serviceaccount" . -}}
-{{- include "cf-common-0.25.0.rbac" . -}}
-{{- include "cf-common-0.25.0.pvc" . -}}
+{{- include "cf-common-0.26.0.controller" . -}}
+{{- include "cf-common-0.26.0.service" . -}}
+{{- include "cf-common-0.26.0.configmaps" . -}}
+{{- include "cf-common-0.26.0.secrets" . -}}
+{{- include "cf-common-0.26.0.serviceaccount" . -}}
+{{- include "cf-common-0.26.0.rbac" . -}}
+{{- include "cf-common-0.26.0.pvc" . -}}
 
 {{- end -}}

--- a/charts/cf-common/templates/render/_configmaps.tpl
+++ b/charts/cf-common/templates/render/_configmaps.tpl
@@ -1,31 +1,31 @@
 {{/*
 Renders ConfigMaps templates.
 Must be called from chart root context.
-{{- include "cf-common-0.25.0.configmaps" . -}}
+{{- include "cf-common-0.26.0.configmaps" . -}}
 */}}
 
-{{- define "cf-common-0.25.0.configmaps" -}}
+{{- define "cf-common-0.26.0.configmaps" -}}
 
 {{- range $configMapIndex, $configMapItem := .Values.configMaps }}
 
 {{- if $configMapItem.enabled }}
-{{ $configMapName := printf "%s-%s" (include "cf-common-0.25.0.names.fullname" $) $configMapIndex }}
+{{ $configMapName := printf "%s-%s" (include "cf-common-0.26.0.names.fullname" $) $configMapIndex }}
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ $configMapName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" $ | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" $ | nindent 4 }}
   {{- if $configMapItem.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $configMapItem.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $configMapItem.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if $configMapItem.annotations }}
-  annotations: {{- include "cf-common-0.25.0.tplrender" (dict "Values" $configMapItem.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "cf-common-0.26.0.tplrender" (dict "Values" $configMapItem.annotations "context" $) | nindent 4 }}
   {{- end }}
   {{- if not ( or (kindIs "map" $configMapItem.data) (kindIs "string" $configMapItem.data)) }}
     {{- fail (printf "ERROR: configMaps.%s.data must be a map or multiline string!" $configMapIndex) }}
   {{- end }}
-data: {{ include "cf-common-0.25.0.tplrender" (dict "Values" $configMapItem.data "context" $) | nindent 2 }}
+data: {{ include "cf-common-0.26.0.tplrender" (dict "Values" $configMapItem.data "context" $) | nindent 2 }}
 {{- end }}
 
 {{- end }}

--- a/charts/cf-common/templates/render/_extra_resources.tpl
+++ b/charts/cf-common/templates/render/_extra_resources.tpl
@@ -2,16 +2,16 @@
 Renders Extra objects defined at .Values.extraResources
 Must be called from chart root context.
 Usage:
-{{- include "cf-common-0.25.0.extraResources" . -}}
+{{- include "cf-common-0.26.0.extraResources" . -}}
 */}}
 
-{{- define "cf-common-0.25.0.extraResources" -}}
+{{- define "cf-common-0.26.0.extraResources" -}}
 
 {{/* Restoring root $ context */}}
 {{- $ := .context -}}
 
 {{- range .Values.extraResources }}
-{{ include "cf-common-0.25.0.tplrender" (dict "Values" . "context" $) }}
+{{ include "cf-common-0.26.0.tplrender" (dict "Values" . "context" $) }}
 {{- end }}
 
 {{- end -}}

--- a/charts/cf-common/templates/render/_hpa.tpl
+++ b/charts/cf-common/templates/render/_hpa.tpl
@@ -2,10 +2,10 @@
 Renders HorizontalPodAutoscaler template.
 Must be called from chart root context.
 Usage:
-{{- include "cf-common-0.25.0.hpa" . -}}
+{{- include "cf-common-0.26.0.hpa" . -}}
 */}}
 
-{{- define "cf-common-0.25.0.hpa" -}}
+{{- define "cf-common-0.26.0.hpa" -}}
 
 {{- if .Values.hpa.enabled -}}
 
@@ -19,11 +19,11 @@ Usage:
 {{- $mergedControllerValues := mergeOverwrite $globalControllerValues $defaultControllerValues -}}
 {{- $_ := set .Values "controller" (deepCopy $mergedControllerValues) -}}
 
-apiVersion: {{ include "cf-common-0.25.0.apiVersion.autoscaling" . }}
+apiVersion: {{ include "cf-common-0.26.0.apiVersion.autoscaling" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" . }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" . }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
 spec:
   scaleTargetRef:
     {{- if eq .Values.controller.type "deployment" }}
@@ -33,7 +33,7 @@ spec:
     apiVersion: argoproj.io/v1alpha1
     kind: Rollout
     {{- end }}
-    name: {{ include "cf-common-0.25.0.names.fullname" . }}
+    name: {{ include "cf-common-0.26.0.names.fullname" . }}
   minReplicas: {{ required "hpa.minReplicas is required!" .Values.hpa.minReplicas | int }}
   maxReplicas: {{ required "hpa.maxReplicas is required!" .Values.hpa.maxReplicas | int }}
   metrics:

--- a/charts/cf-common/templates/render/_pdb.tpl
+++ b/charts/cf-common/templates/render/_pdb.tpl
@@ -1,18 +1,18 @@
 {{/*
 Renders PodDisruptionBudget object.
 Must be called from chart root context.
-{{- include "cf-common-0.25.0.pdb" . -}}
+{{- include "cf-common-0.26.0.pdb" . -}}
 */}}
 
-{{- define "cf-common-0.25.0.pdb" -}}
+{{- define "cf-common-0.26.0.pdb" -}}
 
 {{- if .Values.pdb.enabled -}}
 
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" . }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" . }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
 spec:
 {{- if or .Values.pdb.minAvailable .Values.pdb.maxUnavailable }}
   {{- with .Values.pdb.minAvailable }}
@@ -25,7 +25,7 @@ spec:
   {{- fail (printf "ERROR: pdb.minAvailable or pdb.maxUnavailable is required!" ) }}
 {{- end }}
   selector:
-    matchLabels: {{ include "cf-common-0.25.0.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{ include "cf-common-0.26.0.labels.matchLabels" . | nindent 6 }}
 
 {{- end -}}
 

--- a/charts/cf-common/templates/render/_podMontor.tpl
+++ b/charts/cf-common/templates/render/_podMontor.tpl
@@ -2,11 +2,11 @@
 Renders Service Monitor objects.
 */}}
 
-{{- define "cf-common-0.25.0.podMonitor" -}}
+{{- define "cf-common-0.26.0.podMonitor" -}}
 
 {{- range $podMonitorIndex, $podMonitorItem := .Values.podMonitor -}}
 
-{{- $podMonitorName := include "cf-common-0.25.0.names.fullname" $ -}}
+{{- $podMonitorName := include "cf-common-0.26.0.names.fullname" $ -}}
 {{- if and (hasKey $podMonitorItem "nameOverride") $podMonitorItem.nameOverride -}}
   {{- $podMonitorName = printf "%v-%v" $podMonitorName $podMonitorItem.nameOverride -}}
 {{- end -}}
@@ -20,24 +20,24 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ $podMonitorName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" $ | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" $ | nindent 4 }}
   {{- if $podMonitorItem.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $podMonitorItem.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $podMonitorItem.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if $podMonitorItem.annotations }}
-  annotations: {{- include "cf-common-0.25.0.tplrender" (dict "Values" $podMonitorItem.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "cf-common-0.26.0.tplrender" (dict "Values" $podMonitorItem.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   selector:
     {{- if $podMonitorItem.selector }}
-    {{- include "cf-common-0.25.0.tplrender" (dict "Values" $podMonitorItem.selector "context" $) | nindent 4 }}
+    {{- include "cf-common-0.26.0.tplrender" (dict "Values" $podMonitorItem.selector "context" $) | nindent 4 }}
     {{- else }}
     matchLabels:
-      {{- include "cf-common-0.25.0.labels.matchLabels" $ | nindent 6 }}
+      {{- include "cf-common-0.26.0.labels.matchLabels" $ | nindent 6 }}
     {{- end }}
   {{- if $podMonitorItem.namespaceSelector }}
   namespaceSelector:
-    {{- include "cf-common-0.25.0.tplrender" (dict "Values" $podMonitorItem.namespaceSelector "context" $) | nindent 6 }}
+    {{- include "cf-common-0.26.0.tplrender" (dict "Values" $podMonitorItem.namespaceSelector "context" $) | nindent 6 }}
   {{- else }}
   namespaceSelector:
     matchNames:

--- a/charts/cf-common/templates/render/_rbac.tpl
+++ b/charts/cf-common/templates/render/_rbac.tpl
@@ -2,23 +2,23 @@
 Renders ServiceAccount/Role/RoleBinding objects.
 Must be called from chart root context.
 Usage:
-{{- include "cf-common-0.25.0.rbac" . -}}
+{{- include "cf-common-0.26.0.rbac" . -}}
 */}}
 
-{{- define "cf-common-0.25.0.rbac" -}}
+{{- define "cf-common-0.26.0.rbac" -}}
 
 {{- if .Values.serviceAccount.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default ( include "cf-common-0.25.0.names.fullname" $) .Values.serviceAccount.nameOverride }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ default ( include "cf-common-0.26.0.names.fullname" $) .Values.serviceAccount.nameOverride }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}
-  annotations: {{ include "cf-common-0.25.0.tplrender" (dict "Values" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+  annotations: {{ include "cf-common-0.26.0.tplrender" (dict "Values" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
   {{- end }}
 secrets:
-  - name: {{ include "cf-common-0.25.0.names.fullname" $ }}-sa-token
+  - name: {{ include "cf-common-0.26.0.names.fullname" $ }}-sa-token
 {{- end }}
 
 
@@ -27,22 +27,22 @@ secrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.rbac.namespaced | ternary "Role" "ClusterRole" }}
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" $ }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
-rules: {{ include "cf-common-0.25.0.tplrender" (dict "Values" .Values.rbac.rules "context" $) | nindent 2 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" $ }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
+rules: {{ include "cf-common-0.26.0.tplrender" (dict "Values" .Values.rbac.rules "context" $) | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.rbac.namespaced | ternary "RoleBinding" "ClusterRoleBinding" }}
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" $ }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" $ }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
 roleRef:
   kind: {{ .Values.rbac.namespaced | ternary "Role" "ClusterRole" }}
-  name: {{ include "cf-common-0.25.0.names.fullname" $ }}
+  name: {{ include "cf-common-0.26.0.names.fullname" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: {{ default ( include "cf-common-0.25.0.names.fullname" $) .Values.serviceAccount.nameOverride }}
+    name: {{ default ( include "cf-common-0.26.0.names.fullname" $) .Values.serviceAccount.nameOverride }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
@@ -54,9 +54,9 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/service-account-token
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" $ }}-sa-token
+  name: {{ include "cf-common-0.26.0.names.fullname" $ }}-sa-token
   annotations:
-    kubernetes.io/service-account.name: {{ default ( include "cf-common-0.25.0.names.fullname" $) .Values.serviceAccount.nameOverride }}
+    kubernetes.io/service-account.name: {{ default ( include "cf-common-0.26.0.names.fullname" $) .Values.serviceAccount.nameOverride }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/cf-common/templates/render/_secrets.tpl
+++ b/charts/cf-common/templates/render/_secrets.tpl
@@ -1,25 +1,25 @@
 {{/*
 Renders Secrets objects.
 Must be called from chart root context.
-{{- include "cf-common-0.25.0.secrets" . -}}
+{{- include "cf-common-0.26.0.secrets" . -}}
 */}}
-{{- define "cf-common-0.25.0.secrets" -}}
+{{- define "cf-common-0.26.0.secrets" -}}
 
 {{- range $secretIndex, $secretItem := .Values.secrets }}
 
 {{- if $secretItem.enabled }}
-{{- $secretName := printf "%s-%s" (include "cf-common-0.25.0.names.fullname" $) $secretIndex }}
+{{- $secretName := printf "%s-%s" (include "cf-common-0.26.0.names.fullname" $) $secretIndex }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" $ | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" $ | nindent 4 }}
   {{- if $secretItem.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $secretItem.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $secretItem.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if $secretItem.annotations }}
-  annotations: {{- include "cf-common-0.25.0.tplrender" (dict "Values" $secretItem.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "cf-common-0.26.0.tplrender" (dict "Values" $secretItem.annotations "context" $) | nindent 4 }}
   {{- end }}
 {{- with $secretItem.type }}
 type: {{ . }}
@@ -28,7 +28,7 @@ type: {{ . }}
   {{- if not ( or (kindIs "map" $secretItem.stringData) (kindIs "string" $secretItem.stringData) ) }}
     {{- fail (printf "ERROR: secrets.%s.stringData must be a map or multiline string!" $secretIndex) }}
   {{- end }}
-stringData: {{ include "cf-common-0.25.0.tplrender" (dict "Values" $secretItem.stringData "context" $) | nindent 2 }}
+stringData: {{ include "cf-common-0.26.0.tplrender" (dict "Values" $secretItem.stringData "context" $) | nindent 2 }}
 {{- else if $secretItem.data }}
   {{- if not (kindIs "map" $secretItem.data ) }}
     {{- fail (printf "ERROR: secrets.%s.data must be a map" $secretIndex) }}

--- a/charts/cf-common/templates/render/_serviceMonitor.tpl
+++ b/charts/cf-common/templates/render/_serviceMonitor.tpl
@@ -2,11 +2,11 @@
 Renders Service Monitor objects.
 */}}
 
-{{- define "cf-common-0.25.0.serviceMonitor" -}}
+{{- define "cf-common-0.26.0.serviceMonitor" -}}
 
 {{- range $serviceMonitorIndex, $serviceMonitorItem := .Values.serviceMonitor -}}
 
-{{- $serviceMonitorName := include "cf-common-0.25.0.names.fullname" $ -}}
+{{- $serviceMonitorName := include "cf-common-0.26.0.names.fullname" $ -}}
 {{- if and (hasKey $serviceMonitorItem "nameOverride") $serviceMonitorItem.nameOverride -}}
   {{- $serviceMonitorName = printf "%v-%v" $serviceMonitorName $serviceMonitorItem.nameOverride -}}
 {{- end -}}
@@ -20,24 +20,24 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ $serviceMonitorName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" $ | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" $ | nindent 4 }}
   {{- if $serviceMonitorItem.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $serviceMonitorItem.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $serviceMonitorItem.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if $serviceMonitorItem.annotations }}
-  annotations: {{- include "cf-common-0.25.0.tplrender" (dict "Values" $serviceMonitorItem.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "cf-common-0.26.0.tplrender" (dict "Values" $serviceMonitorItem.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   selector:
     {{- if $serviceMonitorItem.selector }}
-    {{- include "cf-common-0.25.0.tplrender" (dict "Values" $serviceMonitorItem.selector "context" $) | nindent 4 }}
+    {{- include "cf-common-0.26.0.tplrender" (dict "Values" $serviceMonitorItem.selector "context" $) | nindent 4 }}
     {{- else }}
     matchLabels:
-      {{- include "cf-common-0.25.0.labels.matchLabels" $ | nindent 6 }}
+      {{- include "cf-common-0.26.0.labels.matchLabels" $ | nindent 6 }}
     {{- end }}
   {{- if $serviceMonitorItem.namespaceSelector }}
   namespaceSelector:
-    {{- include "cf-common-0.25.0.tplrender" (dict "Values" $serviceMonitorItem.namespaceSelector "context" $) | nindent 6 }}
+    {{- include "cf-common-0.26.0.tplrender" (dict "Values" $serviceMonitorItem.namespaceSelector "context" $) | nindent 6 }}
   {{- else }}
   namespaceSelector:
     matchNames:

--- a/charts/cf-common/templates/services/_primary_port.tpl
+++ b/charts/cf-common/templates/services/_primary_port.tpl
@@ -2,9 +2,9 @@
 Return the primary port for a given Service object.
 Called from ingress template.
 Usage:
-{{ include "cf-common-0.25.0.service.primaryPort" (dict "values" .Values.service.main ) }}
+{{ include "cf-common-0.26.0.service.primaryPort" (dict "values" .Values.service.main ) }}
 */}}
-{{- define "cf-common-0.25.0.service.primaryPort" -}}
+{{- define "cf-common-0.26.0.service.primaryPort" -}}
   {{- $result := "" -}}
   {{- range $name, $port := .values.ports -}}
     {{- if and (hasKey $port "primary") $port.primary -}}

--- a/charts/cf-common/templates/services/_primary_svc.tpl
+++ b/charts/cf-common/templates/services/_primary_svc.tpl
@@ -2,9 +2,9 @@
 Return the primary service object.
 Called from ingress template.
 Usage:
-{{ include "cf-common-0.25.0.service.primary" (dict "values" .Values.service) }}
+{{ include "cf-common-0.26.0.service.primary" (dict "values" .Values.service) }}
 */}}
-{{- define "cf-common-0.25.0.service.primary" -}}
+{{- define "cf-common-0.26.0.service.primary" -}}
   {{- $result := "" -}}
 
   {{- range $name, $service := .values -}}

--- a/charts/cf-common/templates/services/_services.tpl
+++ b/charts/cf-common/templates/services/_services.tpl
@@ -2,16 +2,16 @@
 Renders Services objects.
 Must be called from chart root context.
 Usage:
-{{- include "cf-common-0.25.0.service" . -}}
+{{- include "cf-common-0.26.0.service" . -}}
 */}}
 
-{{- define "cf-common-0.25.0.service" }}
+{{- define "cf-common-0.26.0.service" }}
 
 {{- if not (kindIs "map" .Values.service) }}
   {{- fail "ERROR: service block must be a map!" }}
 {{- end }}
 
-{{- $primary := include "cf-common-0.25.0.service.primary" (dict "values" .Values.service) -}}
+{{- $primary := include "cf-common-0.26.0.service.primary" (dict "values" .Values.service) -}}
 
 {{- range $serviceIndex, $serviceItem := .Values.service }}
 
@@ -23,9 +23,9 @@ Usage:
 {{- end -}}
 
 {{- if eq $serviceIndex $primary }}
-  {{- $serviceName = include "cf-common-0.25.0.names.fullname" $ -}}
+  {{- $serviceName = include "cf-common-0.26.0.names.fullname" $ -}}
 {{- else }}
-  {{- $serviceName = printf "%s-%s" (include "cf-common-0.25.0.names.fullname" $) $serviceIndex -}}
+  {{- $serviceName = printf "%s-%s" (include "cf-common-0.26.0.names.fullname" $) $serviceIndex -}}
 {{- end }}
 
   {{- if $serviceItem.enabled }}
@@ -34,12 +34,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $serviceName }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" $ | nindent 4 }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" $ | nindent 4 }}
   {{- if $serviceItem.labels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $serviceItem.labels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $serviceItem.labels "context" $) | nindent 4 }}
   {{- end }}
   {{- if $serviceItem.annotations }}
-  annotations: {{- include "cf-common-0.25.0.tplrender" (dict "Values" $serviceItem.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "cf-common-0.26.0.tplrender" (dict "Values" $serviceItem.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ $serviceType }}
@@ -87,9 +87,9 @@ spec:
       nodePort: {{ $portItem.nodePort }}
       {{- end }}
     {{- end }}
-  selector: {{ include "cf-common-0.25.0.labels.matchLabels" $ | nindent 4 }}
+  selector: {{ include "cf-common-0.26.0.labels.matchLabels" $ | nindent 4 }}
     {{- if $serviceItem.extraSelectorLabels }}
-  {{- include "cf-common-0.25.0.tplrender" (dict "Values" $serviceItem.extraSelectorLabels "context" $) | nindent 4 }}
+  {{- include "cf-common-0.26.0.tplrender" (dict "Values" $serviceItem.extraSelectorLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/cf-common/templates/signadot/_virtualservice.tpl
+++ b/charts/cf-common/templates/signadot/_virtualservice.tpl
@@ -1,27 +1,27 @@
-{{- define "cf-common-0.25.0.signadot.virtualservice" }}
+{{- define "cf-common-0.26.0.signadot.virtualservice" }}
   {{- if .Values.signadot.enabled }}
 
-{{- $controllerName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- $controllerName := include "cf-common-0.26.0.names.fullname" . -}}
   {{- if and (hasKey .Values.controller "nameOverride") .Values.controller.nameOverride -}}
     {{- $controllerName = printf "%v-%v" $controllerName .Values.controller.nameOverride -}}
   {{- end -}}
-{{- $containerName := include "cf-common-0.25.0.names.fullname" . -}}
+{{- $containerName := include "cf-common-0.26.0.names.fullname" . -}}
   {{- if and (hasKey .Values.container "nameOverride") .Values.container.nameOverride }}
-    {{- $containerName = include "cf-common-0.25.0.tplrender" (dict "Values" .Values.container.nameOverride "context" .) -}}
+    {{- $containerName = include "cf-common-0.26.0.tplrender" (dict "Values" .Values.container.nameOverride "context" .) -}}
   {{- end }}
 
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ include "cf-common-0.25.0.names.fullname" . }}
-  labels: {{ include "cf-common-0.25.0.labels.standard" . | nindent 4 }}
+  name: {{ include "cf-common-0.26.0.names.fullname" . }}
+  labels: {{ include "cf-common-0.26.0.labels.standard" . | nindent 4 }}
 spec:
   hosts:
-  - {{ printf "%s.%s.svc.%s" (include "cf-common-0.25.0.names.fullname" .) .Release.Namespace .Values.global.clusterDomain }}
+  - {{ printf "%s.%s.svc.%s" (include "cf-common-0.26.0.names.fullname" .) .Release.Namespace .Values.global.clusterDomain }}
   http:
   - route:
     - destination:
-        host: {{ include "cf-common-0.25.0.names.fullname" . }}
+        host: {{ include "cf-common-0.26.0.names.fullname" . }}
         port:
           number: {{ .Values.signadot.virtualservice.port  | default "80" }}
   {{- end }}


### PR DESCRIPTION
## What

Handle case when global imagePullSecrets can be provided as list of maps like:
```yaml
global:
  imagePullSecrets:
    - name: my-reg-secrets
```
or list of strings like:
```yaml
global:
  imagePullSecrets:
    - my-reg-secrets
```

The resulting manifest should always have a proper spec
```yaml
spec:
  template:
    spec:
      imagePullSecrets:
        - name: my-reg-secrets
```
and NOT
```yaml
spec:
  template:
    spec:
      imagePullSecrets:
        - name: name my-reg-secrets
```

## Why

## Notes

See `charts/cf-common/templates/container/_image.tpl` for changes