### PR TITLE
chore: (CR-28868-internal-gateway): upgrade nginx for internal-gateway

### DIFF
--- a/charts/internal-gateway/Chart.yaml
+++ b/charts/internal-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.0.0
 description: A Helm chart for Codefresh Internal Gateway
 name: internal-gateway
-version: 0.10.5
+version: 0.10.6
 home: https://github.com/codefresh-io/helm-charts
 keywords:
   - codefresh

--- a/charts/internal-gateway/values.yaml
+++ b/charts/internal-gateway/values.yaml
@@ -192,7 +192,7 @@ container:
   image:
     registry: docker.io
     repository: nginxinc/nginx-unprivileged
-    tag: 1.27-alpine
+    tag: 1.29-alpine
 
   env: {}
   envFrom: []


### PR DESCRIPTION
## What

## Why

## Notes